### PR TITLE
Improving Code quality by fixing overridden next() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 
+# VIM
+*.swp
+
 # C extensions
 *.so
 

--- a/wye/profiles/views.py
+++ b/wye/profiles/views.py
@@ -12,8 +12,8 @@ from . import models
 # Create your views here.
 def registration(request):
     template = loader.get_template('auth/signup.html')
-    next = request.GET.get('next', '')
-    redirect_url = next
+    redirect_next = request.GET.get('next', '')
+    redirect_url = redirect_next
     if request.method == 'POST':
         form = forms.SignupForm(request.POST)
         if form.is_valid():
@@ -40,14 +40,14 @@ def registration(request):
                              dict(
                                  form=form,
                                  redirect_url=redirect_url,
-                                 next=next))
+                                 next=redirect_next))
     return HttpResponse(template.render(context))
 
 
 def login(request):
     template = loader.get_template('auth/login.html')
-    next = request.GET.get('next', '')
-    redirect_url = next
+    redirect_next = request.GET.get('next', '')
+    redirect_url = redirect_next
     if request.method == 'POST':
         form = forms.UserAuthenticationForm(None, request.POST)
         print(form.is_valid())
@@ -89,7 +89,7 @@ def login(request):
                              dict(
                                  form=form,
                                  redirect_url=redirect_url,
-                                 next=next))
+                                 next=redirect_next))
     return HttpResponse(template.render(context))
 
 


### PR DESCRIPTION
As next is the keyword, it should not be redefined in codebase. It will create messy confusions at the time of real use of [next()](https://docs.python.org/3/library/functions.html#next).