### PR TITLE
STATIC_ROOT added to settings

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -137,6 +137,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+STATIC_ROOT = 'static/'
+
 STATICFILES_DIRS = (
     os.path.join(APP_DIR, 'static'),
 )


### PR DESCRIPTION
The obvious `STATIC_ROOT` was missing in the settings. I am not sure whether this points correctly or not, but this should be there. 