### PR TITLE
extra inverted comma removed

### DIFF
--- a/wye/templates/workshops/workshop_list.html
+++ b/wye/templates/workshops/workshop_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <section>
-<a href="{% url 'workshops:workshop_create'  %}"" class="btn btn-primary btn-lg "> Request for workshop </a>
+<a href="{% url 'workshops:workshop_create'  %}" class="btn btn-primary btn-lg "> Request for workshop </a>
 </section>
 <section>
 {% for workshop in workshop_list %}
@@ -11,6 +11,5 @@
     <br />
 {% endfor %}
 </section>
-{{workshop}}
 
 {% endblock %}


### PR DESCRIPTION
This removes a extra inverted comma after the closing of `href` attribute. Also it removes the variable `{{workshop}}` after section, which I think is not required.