### PR TITLE
extra inverted comma removed

### DIFF
--- a/wye/templates/workshops/workshop_list.html
+++ b/wye/templates/workshops/workshop_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <section>
-<a href="{% url 'workshops:workshop_create'  %}"" class="btn btn-primary btn-lg "> Request for workshop </a>
+<a href="{% url 'workshops:workshop_create'  %}" class="btn btn-primary btn-lg "> Request for workshop </a>
 </section>
 <section>
 {% for workshop in workshop_list %}


### PR DESCRIPTION
This removes a extra inverted comma in `workshop_list.html` template.