### PR TITLE
url fix for slug and missing django template ending brackets

### DIFF
--- a/wye/templates/profile/index.html
+++ b/wye/templates/profile/index.html
@@ -7,6 +7,6 @@
 <div>No of workshop upcoming: </div>
 <div>No of Students : {{object.get_total_no_of_participants}}</div>
 <div>Last Workshop Date: {{object.get_last_workshop_date}}</div>
-<div>Tutors Avg rating: {{object.get_avg_workshop_rating</div>
+<div>Tutors Avg rating: {{object.get_avg_workshop_rating}}</div>
 </div>
 {% endblock %}

--- a/wye/urls.py
+++ b/wye/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
         include('wye.organisations.urls', namespace="organisations")),
     url(r'^workshop/',
         include('wye.workshops.urls', namespace="workshops")),
-    url(r'^profile/(?P<slug>[a-zA-Z0-9]+)/$',
+    url(r'^profile/(?P<slug>[a-zA-Z0-9-]+)/$',
         ProfileView.as_view(), name='profile-page'),
     url(r'^region/',
         include('wye.regions.urls', namespace="regions")),


### PR DESCRIPTION
For the profile url, there should be a `-` in the regex for url. 
Also it fixed the missing closing template tags in `profile/index.html`