### PR TITLE
Profile create on login

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -153,6 +153,7 @@ REST_FRAMEWORK = {
     ),
 }
 
+AUTH_PROFILE_MODULE = 'profiles.Profile'
 LOGIN_URL = '/accounts/login'
 LOGIN_REDIRECT_URL = '/'
 ALLOWED_DATE_FORMAT = (

--- a/wye/profiles/forms.py
+++ b/wye/profiles/forms.py
@@ -29,5 +29,11 @@ class SignupForm(UserCreationForm):
                              required=True)
 
 
-class UserProfile(forms.ModelForm):
-    model = models.Profile
+class UserProfileForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(UserProfileForm, self).__init__(*args, **kwargs)
+
+    class Meta:
+        model = models.Profile
+        exclude = ('user', 'slug')

--- a/wye/profiles/models.py
+++ b/wye/profiles/models.py
@@ -7,7 +7,7 @@ from wye.regions.models import Location
 from wye.workshops.models import Workshop
 from wye.workshops.models import WorkshopSections
 
-# from django.db.models.signals import post_save
+from django.db.models.signals import post_save
 # from django.dispatch import receiver
 # from rest_framework.authtoken.models import Token
 
@@ -40,6 +40,9 @@ class Profile(models.Model):
     usertype = models.ManyToManyField(UserType)
     interested_sections = models.ManyToManyField(WorkshopSections)
     interested_locations = models.ManyToManyField(Location)
+
+    REQUIRED_FIELDS = ('user', )
+    USERNAME_FIELD = 'slug'
 
     class Meta:
         db_table = 'user_profile'
@@ -98,3 +101,10 @@ class Profile(models.Model):
 # def create_auth_token(sender, instance=None, created=False, **kwargs):
 #     if created:
 #         token, created = Token.objects.get_or_create(user=instance)
+
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        profile, created = Profile.objects.get_or_create(user=instance)
+
+
+post_save.connect(create_user_profile, sender=User, dispatch_uid='create_user_profile')

--- a/wye/profiles/models.py
+++ b/wye/profiles/models.py
@@ -102,6 +102,7 @@ class Profile(models.Model):
 #     if created:
 #         token, created = Token.objects.get_or_create(user=instance)
 
+
 def create_user_profile(sender, instance, created, **kwargs):
     if created:
         profile, created = Profile.objects.get_or_create(user=instance)

--- a/wye/profiles/urls.py
+++ b/wye/profiles/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url
+from . import views
+
+urlpatterns = [
+    url(r'^create/$', views.ProfileCreateView.as_view(),
+        name="profile_create"),
+    url(r'^(?P<slug>[a-zA-Z0-9]+)/$', views.ProfileView.as_view(),
+        name='profile_page'),
+    url(r'^dashboard$', views.UserDashboard.as_view(),
+        name="dashboard"),
+]

--- a/wye/profiles/views.py
+++ b/wye/profiles/views.py
@@ -2,6 +2,7 @@ from django.views import generic
 from django.views.generic.list import ListView
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect
+from django.shortcuts import render
 
 from braces import views
 

--- a/wye/profiles/views.py
+++ b/wye/profiles/views.py
@@ -1,8 +1,7 @@
 from django.views import generic
 from django.views.generic.list import ListView
 from django.core.urlresolvers import reverse_lazy
-from django.http.response import HttpResponseRedirect
-from django.shortcuts import render
+from django.http import HttpResponseRedirect
 
 from braces import views
 
@@ -33,13 +32,12 @@ class ProfileCreateView(views.LoginRequiredMixin, generic.CreateView):
     success_url = reverse_lazy('profiles:dashboard')
 
     def post(self, request, *args, **kwargs):
-        form = UserProfileForm(data=request.POST)
+        profile = models.Profile.objects.get(user=request.user)
+        form = UserProfileForm(data=request.POST, instance=profile)
         if form.is_valid():
-            new_profile = form.save(commit=False)
-            new_profile.user = request.user
-            new_profile.slug = request.user.username
-            new_profile.save()
-            form.save_m2m()
+            profile.slug = request.user.username
+            profile.save()
+            form.save()
             return HttpResponseRedirect(self.success_url)
         else:
             return render(request, self.template_name, {'form': form})

--- a/wye/profiles/views.py
+++ b/wye/profiles/views.py
@@ -1,13 +1,19 @@
-from django.views.generic import DetailView
+from django.views import generic
 from django.views.generic.list import ListView
+from django.core.urlresolvers import reverse_lazy
+from django.http.response import HttpResponseRedirect
+from django.shortcuts import render
+
+from braces import views
 
 from . import models
+from .forms import UserProfileForm
 from wye.workshops.models import Workshop
 from wye.base.constants import WorkshopStatus
 from wye.organisations.models import Organisation
 
 
-class ProfileView(DetailView):
+class ProfileView(generic.DetailView):
     model = models.Profile
     template_name = 'profile/index.html'
 
@@ -18,6 +24,25 @@ class ProfileView(DetailView):
         context = super(
             ProfileView, self).get_context_data(*args, **kwargs)
         return context
+
+
+class ProfileCreateView(views.LoginRequiredMixin, generic.CreateView):
+    model = models.Profile
+    template_name = 'profile/profile_create.html'
+    form_class = UserProfileForm
+    success_url = reverse_lazy('profiles:dashboard')
+
+    def post(self, request, *args, **kwargs):
+        form = UserProfileForm(data=request.POST)
+        if form.is_valid():
+            new_profile = form.save(commit=False)
+            new_profile.user = request.user
+            new_profile.slug = request.user.username
+            new_profile.save()
+            form.save_m2m()
+            return HttpResponseRedirect(self.success_url)
+        else:
+            return render(request, self.template_name, {'form': form})
 
 
 class UserDashboard(ListView):

--- a/wye/templates/profile/index.html
+++ b/wye/templates/profile/index.html
@@ -11,6 +11,6 @@
 <div>No of workshop upcoming: </div>
 <div>No of Students : {{object.get_total_no_of_participants}}</div>
 <div>Last Workshop Date: {{object.get_last_workshop_date}}</div>
-<div>Tutors Avg rating: {{object.get_avg_workshop_rating</div>
+<div>Tutors Avg rating: {{object.get_avg_workshop_rating}}</div>
 </div>
 {% endblock %}

--- a/wye/templates/profile/profile_create.html
+++ b/wye/templates/profile/profile_create.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% load static from staticfiles %}
+{% include 'autocomplete_light/static.html' %}
+{% block title %}Complete Profile | {{ block.super }}{% endblock %}
+{% block extracss %}
+<script src="{% static 'autocomplete.js' %}"></script>
+{% endblock %}
+
+{% block header %}
+    <div class="fill-theme push-2 text-center">
+        <h1 class="no-space">Complete Profile</h1>
+    </div>
+{% endblock %}
+
+{% block breadcrumbs %}
+    <b>{{ block.super }}</b> » <a href="/profile"><b>Profile</b></a> » Complete Profile
+{% endblock %}
+
+{% block content %}
+    <div class="push-6-bottom">
+        <div class="row">
+            <div class="col-sm-10 col-md-8 col-sm-offset-1 col-md-offset-2">
+                <form method="post" action="{% url 'profiles:profile_create' %}">{% csrf_token %}
+                    {{form.errors}}
+                    {{form.as_p}}
+                    <input type="submit" class="btn btn-theme regular" value="Complete Profile">
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/wye/urls.py
+++ b/wye/urls.py
@@ -6,7 +6,6 @@ from django.contrib import admin
 from django.views.generic.base import TemplateView
 
 from wye.base.views import HomePageView
-from wye.profiles.views import ProfileView, UserDashboard
 
 
 urlpatterns = [
@@ -20,11 +19,10 @@ urlpatterns = [
         include('wye.organisations.urls', namespace="organisations")),
     url(r'^workshop/',
         include('wye.workshops.urls', namespace="workshops")),
-    url(r'^profile/(?P<slug>[a-zA-Z0-9]+)/$',
-        ProfileView.as_view(), name='profile-page'),
+    url(r'^profile/',
+        include('wye.profiles.urls', namespace="profiles")),
     url(r'^region/',
         include('wye.regions.urls', namespace="regions")),
-    url(r'^dashboard/$', UserDashboard.as_view(), name='dashboard'),
     url(r'^$', HomePageView.as_view(),
         name='home-page'),
 ] + static(settings.STATIC_URL, document_root=settings.STATICFILES_DIRS)


### PR DESCRIPTION
This PR accompanies a view which completes the profile of the user. Right now after login the user is not directed to this. Instead the user will have to manually type in the url `/profile/create`. While testing this I used to login at `/django-admin` url instead of `accounts/login`. On successful completion of the profile, the user is redirected to `/profile/dashboard`. These urls can be changed later on as desired.