### PR TITLE
Wye 9 create feadback

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -24,7 +24,7 @@ APP_DIR = join(BASE_DIR, 'wye')
 SECRET_KEY = '(7a-1a$5rsmii8grbapha!r4du4dmh1xnp0p8_(lnx_cx(p7+^'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = []
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -24,7 +24,7 @@ APP_DIR = join(BASE_DIR, 'wye')
 SECRET_KEY = '(7a-1a$5rsmii8grbapha!r4du4dmh1xnp0p8_(lnx_cx(p7+^'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = []
 

--- a/wye/base/constants.py
+++ b/wye/base/constants.py
@@ -54,6 +54,7 @@ class FeedbackType:
     _PRESENTER = [1, "Presenter"]
     _ORGANISATION = [2, "Organisation"]
 
+
 @choices
 class WorkshopRatings:
     _VERY_BAD = [-1, 'Very Bad']
@@ -61,6 +62,7 @@ class WorkshopRatings:
     _NEUTRAL = [0, 'Neutral']
     _GOOD = [1, 'Good']
     _VERY_GOOD = [2, 'Very Good']
+
 
 class WorkshopAction:
     ACTIVE = ('active', 'deactive')

--- a/wye/base/constants.py
+++ b/wye/base/constants.py
@@ -48,6 +48,19 @@ class OrganisationType:
     _OTHERS = [4, "Others"]
 
 
+@choices
+class FeedbackType:
+    _PRESENTER = [1, "Presenter"]
+    _ORGANISATION = [2, "Organisation"]
+
+@choices
+class WorkshopRatings:
+    _VERY_BAD = [-1, 'Very Bad']
+    _BAD = [-2, 'Bad']
+    _NEUTRAL = [0, 'Neutral']
+    _GOOD = [1, 'Good']
+    _VERY_GOOD = [2, 'Very Good']
+
 class WorkshopAction:
     ACTIVE = ('active', 'deactive')
     ASSIGNME = ('opt-in', 'opt-out')

--- a/wye/templates/workshops/workshop_feedback.html
+++ b/wye/templates/workshops/workshop_feedback.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}                                                             
+
+{% block header %}
+    <div class="fill-theme push-2 text-center">
+        <h1 class="no-space">Workshop Feedback</h1>
+    </div>
+{% endblock %}
+
+{% block content %}
+<form method="post" action="">{% csrf_token %}
+{{form.as_p}}
+<input type="submit" value="submit">
+</form>
+{% endblock %}

--- a/wye/workshops/admin.py
+++ b/wye/workshops/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Workshop
+from .models import Workshop, WorkshopFeedBack
 
 
 class WorkshopAdmin(admin.ModelAdmin):
@@ -17,3 +17,9 @@ class WorkshopAdmin(admin.ModelAdmin):
     list_filter = ('is_active', 'status', 'workshop_level', 'location')
 
 admin.site.register(Workshop, WorkshopAdmin)
+
+
+class WorkshopFeedBackAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(WorkshopFeedBack, WorkshopFeedBackAdmin)

--- a/wye/workshops/forms.py
+++ b/wye/workshops/forms.py
@@ -5,7 +5,7 @@ from django.utils.text import slugify
 from wye.base.widgets import CalendarWidget
 from wye.base.constants import WorkshopRatings
 
-from .models import Workshop, WorkshopRatingValues, WorkshopFeedBack  
+from .models import Workshop, WorkshopRatingValues, WorkshopFeedBack
 
 
 class WorkshopForm(forms.ModelForm):
@@ -25,28 +25,27 @@ class WorkshopForm(forms.ModelForm):
 
 class WorkshopFeedbackForm(forms.Form):
     """
-    Dynamically generates feedback form depending on questions available 
+    Dynamically generates feedback form depending on questions available
     in model assigend to question_model.
     """
-    
+
     question_model = WorkshopRatingValues
-    
+
     def __init__(self, *args, **kwargs):
         super(WorkshopFeedbackForm, self).__init__(*args, **kwargs)
         questions = self.question_model.get_questions()
-        
+
         for question in questions:
             key = "{}-{}".format(
                 slugify(question["name"]), question["pk"]
             )
             self.fields[key] = forms.ChoiceField(
-                choices = WorkshopRatings.CHOICES, required=True,
+                choices=WorkshopRatings.CHOICES, required=True,
                 widget=forms.RadioSelect())
             self.fields[key].label = question["name"]
 
         self.fields["comment"] = forms.CharField(widget=forms.Textarea)
 
     def save(self, user, workshop_id):
-        data = {k.split("-")[-1]: v for k,v in self.cleaned_data.iteritems()}    
+        data = {k.split("-")[-1]: v for k, v in self.cleaned_data.iteritems()}
         WorkshopFeedBack.save_feedback(user, workshop_id, **data)
-

--- a/wye/workshops/forms.py
+++ b/wye/workshops/forms.py
@@ -1,10 +1,11 @@
 from django import forms
 from django.conf import settings
+from django.utils.text import slugify
 
 from wye.base.widgets import CalendarWidget
+from wye.base.constants import WorkshopRatings
 
-from django.utils.text import slugify
-from .models import Workshop, WorkshopRatingValues
+from .models import Workshop, WorkshopRatingValues, WorkshopFeedBack  
 
 
 class WorkshopForm(forms.ModelForm):
@@ -22,10 +23,30 @@ class WorkshopForm(forms.ModelForm):
             'is_active')
 
 
-class WorkshopFeedback(forms.Form):
+class WorkshopFeedbackForm(forms.Form):
+    """
+    Dynamically generates feedback form depending on questions available 
+    in model assigend to question_model.
+    """
+    
+    question_model = WorkshopRatingValues
+    
     def __init__(self, *args, **kwargs):
-        questions = WorkshopRatingValues.get_questions()
-
+        super(WorkshopFeedbackForm, self).__init__(*args, **kwargs)
+        questions = self.question_model.get_questions()
+        
         for question in questions:
-            self.fields[slugify(question)] = forms.TextField()
+            key = "{}-{}".format(
+                slugify(question["name"]), question["pk"]
+            )
+            self.fields[key] = forms.ChoiceField(
+                choices = WorkshopRatings.CHOICES, required=True,
+                widget=forms.RadioSelect())
+            self.fields[key].label = question["name"]
+
+        self.fields["comment"] = forms.CharField(widget=forms.Textarea)
+
+    def save(self, user, workshop_id):
+        data = {k.split("-")[-1]: v for k,v in self.cleaned_data.iteritems()}    
+        WorkshopFeedBack.save_feedback(user, workshop_id, **data)
 

--- a/wye/workshops/forms.py
+++ b/wye/workshops/forms.py
@@ -3,7 +3,8 @@ from django.conf import settings
 
 from wye.base.widgets import CalendarWidget
 
-from .models import Workshop
+from django.utils.text import slugify
+from .models import Workshop, WorkshopRatingValues
 
 
 class WorkshopForm(forms.ModelForm):
@@ -19,3 +20,12 @@ class WorkshopForm(forms.ModelForm):
         exclude = (
             'presenter', 'created_at', 'modified_at',
             'is_active')
+
+
+class WorkshopFeedback(forms.Form):
+    def __init__(self, *args, **kwargs):
+        questions = WorkshopRatingValues.get_questions()
+
+        for question in questions:
+            self.fields[slugify(question)] = forms.TextField()
+

--- a/wye/workshops/migrations/0002_auto_20151024_1441.py
+++ b/wye/workshops/migrations/0002_auto_20151024_1441.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='workshop',
+            name='status',
+            field=models.PositiveSmallIntegerField(default=1, verbose_name=b'Current Status', choices=[(3, 'Workshop Accepted '), (5, 'Workshop Completed'), (4, 'Workshop Declined'), (1, 'Draft'), (6, 'Workshop On Hold'), (2, 'Workshop Requested')]),
+        ),
+    ]

--- a/wye/workshops/migrations/0003_auto_20151025_0818.py
+++ b/wye/workshops/migrations/0003_auto_20151025_0818.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0002_auto_20151024_1441'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='workshopvoting',
+            name='rating',
+            field=models.ForeignKey(related_name='workshop_rating', default='', to='workshops.WorkshopRatingValues'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='workshopvoting',
+            name='presenter_rating',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='workshopvoting',
+            name='requester_rating',
+            field=models.IntegerField(),
+        ),
+    ]

--- a/wye/workshops/migrations/0004_auto_20151025_1331.py
+++ b/wye/workshops/migrations/0004_auto_20151025_1331.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0003_auto_20151025_0818'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='workshopfeedback',
+            old_name='presenter_comment',
+            new_name='comment',
+        ),
+        migrations.RemoveField(
+            model_name='workshopfeedback',
+            name='requester_comment',
+        ),
+        migrations.RemoveField(
+            model_name='workshopvoting',
+            name='presenter_rating',
+        ),
+        migrations.RemoveField(
+            model_name='workshopvoting',
+            name='requester_rating',
+        ),
+        migrations.RemoveField(
+            model_name='workshopvoting',
+            name='workshop',
+        ),
+        migrations.AddField(
+            model_name='workshopfeedback',
+            name='user_type',
+            field=models.PositiveSmallIntegerField(default=0, verbose_name=b'User_type', choices=[(2, 'Organisation'), (1, 'Presenter')]),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='workshopvoting',
+            name='workshop_feedback',
+            field=models.ForeignKey(related_name='workshop_feedback', default='', to='workshops.WorkshopFeedBack'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='workshopvoting',
+            name='workshop_rating',
+            field=models.ForeignKey(related_name='workshop_rating', default='', to='workshops.WorkshopRatingValues'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='workshopvoting',
+            name='rating',
+            field=models.IntegerField(),
+        ),
+    ]

--- a/wye/workshops/migrations/0005_auto_20151025_1338.py
+++ b/wye/workshops/migrations/0005_auto_20151025_1338.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0004_auto_20151025_1331'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='workshopfeedback',
+            old_name='user_type',
+            new_name='feedback_type',
+        ),
+    ]

--- a/wye/workshops/migrations/0006_remove_workshopratingvalues_value.py
+++ b/wye/workshops/migrations/0006_remove_workshopratingvalues_value.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0005_auto_20151025_1338'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='workshopratingvalues',
+            name='value',
+        ),
+    ]

--- a/wye/workshops/models.py
+++ b/wye/workshops/models.py
@@ -57,13 +57,13 @@ class Workshop(TimeAuditModel):
 
     def __str__(self):
         return '{}-{}'.format(self.requester, self.workshop_section)
-        
+
     def is_presenter(self, user):
         return self.presenter.filter(pk=user.pk).exists()
-        
+
     def is_organiser(self, user):
         return self.requester.user.filter(pk=user.pk).exists()
-        
+
     @validate_action_param(WorkshopAction.ACTIVE)
     def toggle_active(self, user, **kwargs):
         """
@@ -157,8 +157,7 @@ class WorkshopFeedBack(TimeAuditModel):
 
     def __str__(self):
         return '{}'.format(self.workshop)
-        
-    
+
     @classmethod
     def save_feedback(cls, user, workshop_id, **kwargs):
         workshop = Workshop.objects.get(pk=workshop_id)
@@ -166,17 +165,19 @@ class WorkshopFeedBack(TimeAuditModel):
         organiser = workshop.is_organiser(user)
         comment = kwargs.get('comment', '')
         del kwargs['comment']
-        
+
         if presenter:
             feedback_type = FeedbackType.PRESENTER
         elif organiser:
             feedback_type = FeedbackType.ORGANISATION
-        
-        workshop_feedback = cls.objects.create(workshop=workshop, comment=comment,
-            feedback_type=feedback_type)
-        
+
+        workshop_feedback = cls.objects.create(
+            workshop=workshop,
+            comment=comment,
+            feedback_type=feedback_type
+        )
         WorkshopVoting.save_rating(workshop_feedback, **kwargs)
-        
+
 
 class WorkshopVoting(TimeAuditModel):
     workshop_feedback = models.ForeignKey(
@@ -196,7 +197,8 @@ class WorkshopVoting(TimeAuditModel):
     @classmethod
     def save_rating(cls, workshop_feedback, **kwargs):
         object_list = [
-            cls(workshop_feedback=workshop_feedback, workshop_rating_id=int(k), rating=v)
+            cls(workshop_feedback=workshop_feedback,
+                workshop_rating_id=int(k), rating=v)
             for k, v in kwargs.iteritems()
         ]
 

--- a/wye/workshops/models.py
+++ b/wye/workshops/models.py
@@ -1,7 +1,8 @@
 from django.contrib.auth.models import User
 from django.db import models
 
-from wye.base.constants import WorkshopStatus, WorkshopLevel, WorkshopAction
+from wye.base.constants import WorkshopStatus, WorkshopLevel, WorkshopAction,\
+    FeedbackType
 from wye.base.models import TimeAuditModel
 from wye.organisations.models import Organisation
 from wye.regions.models import Location
@@ -56,7 +57,13 @@ class Workshop(TimeAuditModel):
 
     def __str__(self):
         return '{}-{}'.format(self.requester, self.workshop_section)
-
+        
+    def is_presenter(self, user):
+        return self.presenter.filter(pk=user.pk).exists()
+        
+    def is_organiser(self, user):
+        return self.requester.user.filter(pk=user.pk).exists()
+        
     @validate_action_param(WorkshopAction.ACTIVE)
     def toggle_active(self, user, **kwargs):
         """
@@ -121,47 +128,76 @@ class WorkshopRatingValues(TimeAuditModel):
     '''
     Requesting Rating values -2, -1, 0 , 1, 2
     '''
-    value = models.IntegerField()
+
     name = models.CharField(max_length=300)
 
     class Meta:
         db_table = 'workshop_vote_value'
 
     def __str__(self):
-        return '{}-{}'.format(self.value, self.name)
+        return '{}'.format(self.name)
 
+    @classmethod
     def get_questions(cls):
-        return  cls.obejcts.values('name')
-
-
-class WorkshopVoting(TimeAuditModel):
-    requester_rating = models.ForeignKey(
-        WorkshopRatingValues, related_name='requester_rating')
-    presenter_rating = models.ForeignKey(
-        WorkshopRatingValues, related_name='presenter_rating')
-    workshop = models.ForeignKey(Workshop)
-
-    class Meta:
-        db_table = 'workshop_votes'
-
-    def __str__(self):
-        return '{}-{}-{}'.format(self.workshop,
-                                 self.requester_rating,
-                                 self.presenter_rating)
+        return cls.objects.values('name', 'pk')
 
 
 class WorkshopFeedBack(TimeAuditModel):
     '''
     Requesting for Feedback from requester and Presenter
     '''
-    requester_comment = models.TextField()
-    presenter_comment = models.TextField()
+
     workshop = models.ForeignKey(Workshop)
+    comment = models.TextField()
+    feedback_type = models.PositiveSmallIntegerField(
+        choices=FeedbackType.CHOICES, verbose_name="User_type")
 
     class Meta:
         db_table = 'workshop_feedback'
 
     def __str__(self):
-        return '{}-{}-{}'.format(self.workshop,
-                                 self.requester_rating,
-                                 self.presenter_rating)
+        return '{}'.format(self.workshop)
+        
+    
+    @classmethod
+    def save_feedback(cls, user, workshop_id, **kwargs):
+        workshop = Workshop.objects.get(pk=workshop_id)
+        presenter = workshop.is_presenter(user)
+        organiser = workshop.is_organiser(user)
+        comment = kwargs.get('comment', '')
+        del kwargs['comment']
+        
+        if presenter:
+            feedback_type = FeedbackType.PRESENTER
+        elif organiser:
+            feedback_type = FeedbackType.ORGANISATION
+        
+        workshop_feedback = cls.objects.create(workshop=workshop, comment=comment,
+            feedback_type=feedback_type)
+        
+        WorkshopVoting.save_rating(workshop_feedback, **kwargs)
+        
+
+class WorkshopVoting(TimeAuditModel):
+    workshop_feedback = models.ForeignKey(
+        WorkshopFeedBack, related_name='workshop_feedback')
+    workshop_rating = models.ForeignKey(
+        WorkshopRatingValues, related_name='workshop_rating')
+    rating = models.IntegerField()
+
+    class Meta:
+        db_table = 'workshop_votes'
+
+    def __str__(self):
+        return '{}-{}-{}'.format(self.workshop_feedback,
+                                 self.workshop_rating,
+                                 self.rating)
+
+    @classmethod
+    def save_rating(cls, workshop_feedback, **kwargs):
+        object_list = [
+            cls(workshop_feedback=workshop_feedback, workshop_rating_id=int(k), rating=v)
+            for k, v in kwargs.iteritems()
+        ]
+
+        cls.objects.bulk_create(object_list)

--- a/wye/workshops/models.py
+++ b/wye/workshops/models.py
@@ -130,6 +130,9 @@ class WorkshopRatingValues(TimeAuditModel):
     def __str__(self):
         return '{}-{}'.format(self.value, self.name)
 
+    def get_questions(cls):
+        return  cls.obejcts.values('name')
+
 
 class WorkshopVoting(TimeAuditModel):
     requester_rating = models.ForeignKey(

--- a/wye/workshops/urls.py
+++ b/wye/workshops/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from .views import WorkshopList, WorkshopDetail, \
     WorkshopCreate, WorkshopUpdate, WorkshopToggleActive, \
-    WorkshopAssignMe
+    WorkshopAssignMe, WorkshopFeedbackView
 
 
 urlpatterns = [
@@ -13,5 +13,7 @@ urlpatterns = [
     url(r'^(?P<pk>\d+)/(?P<action>active|deactive)/$',
         WorkshopToggleActive.as_view(), name="workshop_toggle"),
     url(r'^(?P<pk>\d+)/(?P<action>opt-in|opt-out)/$',
-        WorkshopAssignMe.as_view(), name="workshop_assignme")
+        WorkshopAssignMe.as_view(), name="workshop_assignme"),
+    url(r'^(?P<pk>\d+)/feedback/$',
+        WorkshopFeedbackView.as_view(), name="workshop_feedback")
 ]

--- a/wye/workshops/views.py
+++ b/wye/workshops/views.py
@@ -4,7 +4,8 @@ from django.views import generic
 from braces import views
 
 from .forms import WorkshopForm, WorkshopFeedbackForm
-from .mixins import WorkshopEmailMixin, WorkshopAccessMixin
+from .mixins import WorkshopEmailMixin, WorkshopAccessMixin, \
+    WorkshopFeedBackMixin
 from .models import Workshop
 
 
@@ -105,8 +106,8 @@ class WorkshopAssignMe(views.LoginRequiredMixin, views.CsrfExemptMixin,
         self.send_mail_to_group(context, exclude_emails=[user.email])
 
 
-class WorkshopFeedbackView(generic.FormView):
-    model = Workshop
+class WorkshopFeedbackView(views.LoginRequiredMixin, WorkshopFeedBackMixin,
+                           generic.FormView):
     form_class = WorkshopFeedbackForm
     template_name = "workshops/workshop_feedback.html"
     success_url = reverse_lazy('workshops:workshop_list')

--- a/wye/workshops/views.py
+++ b/wye/workshops/views.py
@@ -4,7 +4,7 @@ from django.views import generic
 from braces import views
 # from wye.organisations.models import Organisation
 
-from .forms import WorkshopForm
+from .forms import WorkshopForm, WorkshopFeedbackForm
 from .models import Workshop
 from .mixins import WorkshopEmailMixin
 
@@ -87,6 +87,7 @@ class WorkshopAssignMe(views.LoginRequiredMixin, views.CsrfExemptMixin,
         self.object = self.get_object()
         user = request.user
         response = self.object.assign_me(user, **kwargs)
+        
         if response['status']:
             self.send_mail(user, response['assigned'])
         return self.render_json_response(response)
@@ -109,3 +110,15 @@ class WorkshopAssignMe(views.LoginRequiredMixin, views.CsrfExemptMixin,
         self.send_mail_to_presenter(user, context)
         context['presenter'] = False
         self.send_mail_to_group(context, exclude_emails=[user.email])
+
+
+class WorkshopFeedbackView(generic.FormView):
+    model = Workshop
+    form_class = WorkshopFeedbackForm
+    template_name = "workshops/workshop_feedback.html"
+    success_url = reverse_lazy('workshops:workshop_list')
+
+    def form_valid(self, form):
+        workshop_id = self.kwargs.get('pk')
+        form.save(self.request.user, workshop_id)
+        return super(WorkshopFeedbackView, self).form_valid(form)


### PR DESCRIPTION
Disclaimer: After giving lot of thoughts, It have done changes in models related to workshop feedback. Pls review it carefully.  I have done the change to make insertion/ retrieval of  feedback easy . 

Contains first part implementation for #9 
 Feature that have been implemented
- Dynamic generation of feedback form depending on question in WorkshopRatingValues.
- Form will display all the questions from WorkshopRatingValues models plus a comment box.
- The workshop url will throw 404, unless workshop is completed.

Sample url: http://127.0.0.1:8000/workshop/1/feedback/

Once this is merge, I will add pull request for next part that will contain
- Restricting organisation to add workshop unless they complete feedback
- Restricting presenter to take up next workshop unless they complete feedback
- Display message to presenter/organiser to share feedback.


