### PR TITLE
 Removing fields from signup page. Changing login flow

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -160,7 +160,7 @@ REST_FRAMEWORK = {
 }
 
 LOGIN_URL = '/accounts/login'
-LOGIN_REDIRECT_URL = '/'
+LOGIN_REDIRECT_URLNAME = 'dashboard'
 ALLOWED_DATE_FORMAT = (
     '%d-%m-%Y', '%d/%m/%Y',
     '%d/%m/%y')

--- a/wye/profiles/forms.py
+++ b/wye/profiles/forms.py
@@ -3,8 +3,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import ugettext_lazy as _
 
-from wye.workshops.models import WorkshopSections
-from wye.regions.models import Location
 from . import models
 
 
@@ -23,13 +21,6 @@ class SignupForm(forms.ModelForm):
             attrs={'placeholder': 'Mobile'}
         )
     )
-    usertype = forms.ModelMultipleChoiceField(
-        queryset=models.UserType.objects.exclude(slug='admin'))
-    location = forms.ModelChoiceField(queryset=Location.objects.all())
-    interested_locations = forms.ModelMultipleChoiceField(
-        queryset=Location.objects.all())
-    interested_sections = forms.ModelMultipleChoiceField(
-        queryset=WorkshopSections.objects.all())
 
     class Meta:
         model = get_user_model()
@@ -42,12 +33,7 @@ class SignupForm(forms.ModelForm):
     def signup(self, request, user):
         profile = user.profile
         profile.mobile = self.cleaned_data['mobile']
-        profile.location = self.cleaned_data['location']
-        profile.usertype = self.cleaned_data['usertype']
-        profile.interested_locations = self.cleaned_data['interested_locations']
-        profile.interested_sections = self.cleaned_data['interested_sections']
         profile.save()
-        user.save()
 
 
 class UserProfileForm(forms.ModelForm):

--- a/wye/profiles/views.py
+++ b/wye/profiles/views.py
@@ -33,7 +33,7 @@ class UserDashboard(ListView):
         user_profile = models.Profile.objects.get(
             user__id=self.request.user.id)
         if not user_profile.get_user_type:
-            return redirect('profiles:profile_create')
+            return redirect('profiles:profile-edit', slug=request.user.username)
         return super(UserDashboard, self).dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/wye/templates/profile/update.html
+++ b/wye/templates/profile/update.html
@@ -5,6 +5,11 @@
     <div class="push-6-bottom">
           <div class="row">
             <div class="col-sm-10 col-md-8 col-sm-offset-1 col-md-offset-2">
+              <h2 class="text-center">Update Profile <i class="fa fa-user"></i></h2>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-10 col-md-8 col-sm-offset-1 col-md-offset-2">
                 <form enctype="multipart/form-data" method="post" action="">{% csrf_token %}
                     {{form.errors}}
                     {{form.as_p}}


### PR DESCRIPTION
* **Description:** Removing fields such as User type, location, Interested Sections, Interested Locations from the signup page. First time user will be redirected to Profile Edit page (As Profile is created when User is created so no need for create view here) and User who is having profile information will be redirected to **Dashboard**.

* **Flow**: 
1 User-Signup
2 Conform Mail
3 Login in from Email, Password
4 If User-type is null Go to Step 6 otherwise Go to Next step
5 Redirect to Dashboard
6 Profile Edit

* **Note:** When User is signing up from Social accounts there will not be value for User-type. In this condition user will be automatically redirected to Profile Edit page.
* **Issues:**
1 #126
2 #131 

* **[Video](https://youtu.be/t0W6tdq0HPQ)**