### PR TITLE
mentioning few os level dependencies in the doc

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,13 +3,20 @@
 Follow this guide to setup your development machine.
 
 1. Install [git], [postgresql] and [virtualenv], in your computer, if you don't have it already.
-2. Get the source code on your machine via git.
+2. Ensure that python3-dev and libpq are installed on your system.
+
+    ```shell
+    # if you are using a debian based os for development run:
+    sudo apt-get install -y python3-dev python3-pip libpq-dev libjpeg-dev
+    ```
+
+3. Get the source code on your machine via git.
     
     ```shell
     git clone https://github.com/pythonindia/wye.git
     ```
 
-3. Create an isolated python 3 environment and install python dependencies.
+4. Create an isolated python 3 environment and install python dependencies.
 
     ```shell
     cd wye
@@ -18,13 +25,13 @@ Follow this guide to setup your development machine.
     pip install -r requirements/dev.txt
     ```
 
-4. Copy over `settings/dev.sample.py` to `settings/dev.py`.
+5. Copy over `settings/dev.sample.py` to `settings/dev.py`.
 
     ```
     cp settings/dev.sample.py settings/dev.py
     ```
 
-5. Create an empty postgres database and run database migration.
+6. Create an empty postgres database and run database migration.
 
     ```
     createdb wye
@@ -32,7 +39,7 @@ Follow this guide to setup your development machine.
     python manage.py sample_data
     ```
 
-6. That's it. Now you can run development server and open the site admin at http://localhost:8000/django-admin/ (initial creds: admin / 123123)
+7. That's it. Now you can run development server and open the site admin at http://localhost:8000/django-admin/ (initial creds: admin / 123123)
 
     ```
     python manage.py runserver


### PR DESCRIPTION
Developers not having python3-dev and libpq-dev installed on their system will not be able to run the project.
IMO the setup page should list these as OS level dependencies.