### PR TITLE
Adding Link of Github and Mailing list to Footer

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -39,7 +39,12 @@ SITE_ID = 1
 SITE_VARIABLES = {
     'site_name': os.environ.get('SITE_NAME', 'PythonExpress'),
     'site_description': '',
-    'footer': '&copy; 2014-2015 <a target="_blank" href="http://pssi.org.in/">Python Software Society of India</a>'
+    'footer': (
+        '&copy; 2014-2015 <a target="_blank" href="http://pssi.org.in/">Python Software Society of India</a><br>'
+        '<a target="_blank" href="pythonexpress@pssi.org.in"><i class="fa fa-envelope"></i> Mailing List </a>'
+        '&nbsp;&nbsp;'
+        '<a target="_blank" href="https://github.com/pythonindia/wye"><i class="fa fa-github"></i> Github</a>'
+    )
 }
 
 DEFAULT_APPS = (

--- a/wye/workshops/views.py
+++ b/wye/workshops/views.py
@@ -5,7 +5,6 @@ from django.views import generic
 from braces import views
 from wye.profiles.models import Profile
 from wye.social.sites.twitter import send_tweet
-from wye.organisations.models import Organisation
 
 from .forms import WorkshopForm, WorkshopEditForm, WorkshopFeedbackForm
 from .mixins import WorkshopEmailMixin, WorkshopAccessMixin, \


### PR DESCRIPTION
* **Description:** Mailing list link and Github link of the Python express repository is added to the main footer of the website.

* **Links:**
1 Github: https://github.com/pythonindia/wye
2 MailingList: pythonexpress@pssi.org.in

* **Issues:**
1 #154 

* **Image:**
![about pythonexpress](https://cloud.githubusercontent.com/assets/3719122/10915799/66ebfcf0-827e-11e5-9d3c-b658c66d1410.png)
