### PR TITLE
adds twitter account info in footer

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -44,6 +44,8 @@ SITE_VARIABLES = {
         '<a target="_blank" href="http://lists.pssi.org.in/cgi-bin/mailman/listinfo/pythonexpress"><i class="fa fa-envelope"></i> Mailing List </a>'
         '&nbsp;&nbsp;'
         '<a target="_blank" href="https://github.com/pythonindia/wye"><i class="fa fa-github"></i> Github</a>'
+        '&nbsp;&nbsp;'
+        '<a target="_blank" href="https://twitter.com/pythonexpress/"><i class="fa fa-twitter"></i>Twitter</a>'
     )
 }
 


### PR DESCRIPTION
fixed #185 
![footer_twitter_account](https://cloud.githubusercontent.com/assets/8040201/11179961/1f65015c-8c7d-11e5-9769-71f49d9347e5.png)
