### PR TITLE
Fix: Handle KeyError when no values are specified for location and leads.

### DIFF
--- a/wye/regions/forms.py
+++ b/wye/regions/forms.py
@@ -13,14 +13,16 @@ class RegionalLeadForm(forms.ModelForm):
         exclude = ()
 
     def clean(self):
-        location = self.cleaned_data['location']
         error_message = []
-        for u in self.cleaned_data['leads']:
-            if not u.profile:
-                error_message.append('Profile for user %s not found' % (u))
-            elif u.profile.location != location:
-                error_message.append(
-                    "User %s doesn't belong to region %s" % (u, location))
+        if (self.cleaned_data.get('location', '') and
+                self.cleaned_data.get('leads', '')):
+            location = self.cleaned_data['location']
+            for u in self.cleaned_data['leads']:
+                if not u.profile:
+                    error_message.append('Profile for user %s not found' % (u))
+                elif u.profile.location != location:
+                    error_message.append(
+                        "User %s doesn't belong to region %s" % (u, location))
         if error_message:
             raise ValidationError(error_message)
 


### PR DESCRIPTION
Fixes #230 
Added a if key exist case for both "location" and "leads" parameters which now doesn't show a KeyError and shows "This field is required" alert as expected.