### PR TITLE
fixed the emailer issue that got introduced due to, changes done in to_str method 

### DIFF
--- a/wye/base/emailer.py
+++ b/wye/base/emailer.py
@@ -4,9 +4,9 @@ from django.core import mail
 from django.template.loader import render_to_string
 
 
-def to_str(x, context, template_dir=None):
+def to_str(context, template_file, template_dir=None):
     return render_to_string(
-        os.path.join(template_dir, x), context).strip()
+        os.path.join(template_dir, template_file), context).strip()
 
 
 def send_mail(to, context, template_dir=None):
@@ -21,10 +21,10 @@ def send_mail(to, context, template_dir=None):
 
 #     to_str = lambda x: render_to_string(
 #         os.path.join(template_dir, x), context).strip()
-    subject = to_str(context, 'subject.txt')
+    subject = to_str(context, 'subject.txt', template_dir)
     from_email = settings.DEFAULT_FROM_EMAIL
-    text_message = to_str(context, 'message.txt')
-    html_message = to_str(context, 'message.html')
+    text_message = to_str(context, 'message.txt', template_dir)
+    html_message = to_str(context, 'message.html', template_dir)
     recipient_list = to
     return mail.send_mail(subject, text_message, from_email,
                           recipient_list, html_message=html_message)


### PR DESCRIPTION
**Disclaimer: Please do a quick review of fix, merge and update the production asap. So that we can avoid this emailer issue.**

- Fixed emailer issue that got introduced due to, changes done in **to_str** method  and pushed/merged without the implementations being tested.

- The **to_str** method was moved out from lambda definition to proper method definition.
- With new implementation **to_str**  method expects 3 input arguments. But only 2 arguments provided  while calling the method, that's why trace below was generated and send_mail was failing.

```
Internal Server Error: /workshop/create/
Traceback (most recent call last):
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/braces/views/_access.py", line 98, in dispatch
    request, *args, **kwargs)
  File "./wye/workshops/mixins.py", line 82, in dispatch
    return super(WorkshopRestrictMixin, self).dispatch(request, *args, **kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/views/generic/base.py", line 89, in dispatch
    return handler(request, *args, **kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/views/generic/edit.py", line 249, in post
    return super(BaseCreateView, self).post(request, *args, **kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/views/generic/edit.py", line 215, in post
    return self.form_valid(form)
  File "./wye/workshops/views.py", line 87, in form_valid
    self.send_mail_to_group(context)
  File "./wye/workshops/mixins.py", line 166, in send_mail_to_group
    send_mail(all_email, context, self.email_dir)
  File "./wye/base/emailer.py", line 24, in send_mail
    subject = to_str(context, 'subject.txt')
  File "./wye/base/emailer.py", line 9, in to_str
    os.path.join(template_dir, x), context).strip()
  File "/opt/envs/wye/lib/python2.7/posixpath.py", line 75, in join
    if b.startswith('/'):
AttributeError: 'dict' object has no attribute 'startswith'
``` 
