### PR TITLE
fixed issue for get_leads

### DIFF
--- a/wye/regions/urls.py
+++ b/wye/regions/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
         name="lead-create"),
     url(r'^lead/(?P<pk>\d+)/edit/$', views.RegionalLeadUpdateView.as_view(),
         name="lead-update"),
-    url(r'^lead/get_leads/(?P<l_id>\w+)/$', views.RegionalLeadCreateView.get_leads, name='get_leads'),
+    url(r'^lead/get_leads/(?P<l_id>\w+)/$', views.RegionalLeadCreateView().get_leads, name='get_leads'),
     url(r'^state/create/$', views.StateCreateView.as_view(),
         name="state-create"),
     url(r'^state/(?P<pk>\d+)/edit/$', views.StateEditView.as_view(),

--- a/wye/regions/views.py
+++ b/wye/regions/views.py
@@ -77,13 +77,11 @@ class RegionalLeadCreateView(views.StaffuserRequiredMixin, generic.CreateView):
     success_url = '/region/'
     template_name = 'regions/lead/create.html'
 
-    def get_leads(request, l_id):
-        leads = Profile.objects.filter(location=l_id)
-        lead_choices = []
-        for lead in leads:
-            lead_choices.append((lead.user.id, lead.user.username))
-
-        return HttpResponse(json.dumps(lead_choices))
+    def get_leads(self, request, l_id):
+        lead_choices = Profile.objects.filter(
+            location=l_id
+        ).values_list('user__id', 'user__username')
+        return HttpResponse(json.dumps(list(lead_choices)))
 
     def post(self, request, *args, **kwargs):
         if request.method == 'POST' and request.is_ajax:


### PR DESCRIPTION
Fixed issue for get_leads for error message: unbound method get_leads must be called with RegionalLeadCreateView instance as first argument. 

Following background exception was thrown:
```
Internal Server Error: /region/lead/get_leads/3/
Traceback (most recent call last):
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
TypeError: unbound method get_leads() must be called with RegionalLeadCreateView instance as first argument (got WSGIRequest instance instead)
```

Review and merge the fix.