### PR TITLE
Fixes #327.

### DIFF
--- a/wye/workshops/models.py
+++ b/wye/workshops/models.py
@@ -201,9 +201,13 @@ class Workshop(TimeAuditModel):
         date = workshop.expected_date
         topic = workshop.workshop_section
         organization = workshop.requester
+        location = workshop.location
         workshop_url = context.get('workshop_url', None)
         message = "{} workshop at {} on {} confirmed! Details at {}".format(
             topic, organization, date, workshop_url)
+        if len(message) >= 140:
+            message = "{} workshop at {} on {} confirmed! Details at {}".format(
+                topic, location, date, workshop_url)
         if len(message) >= 140:
             message = "{} workshop on {} confirmed! Details at {}".format(
                 topic, date, workshop_url)


### PR DESCRIPTION
Tries to populate the tweet with just the location instead of the organization name + location to fit in the 140 character limit. Falls back to just the topic and location only after two attempts.

Signed-off-by: Haris Ibrahim K. V <blucalvin@gmail.com>