### PR TITLE
limit celery accept content to json

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -234,3 +234,5 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=7, minute=30),
     },
 }
+
+CELERY_ACCEPT_CONTENT = ['json']


### PR DESCRIPTION
This is a basic good practice when using celery.

http://docs.celeryproject.org/en/latest/configuration.html#std:setting-CELERY_ACCEPT_CONTENT