### PR TITLE
Dashboard throwing 500 when the user not loggedin

### DIFF
--- a/wye/profiles/views.py
+++ b/wye/profiles/views.py
@@ -3,7 +3,7 @@
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect, render, get_object_or_404
 from django.template import Context, loader
 from django.views.generic import UpdateView
 from django.views.generic.list import ListView
@@ -31,8 +31,8 @@ class UserDashboard(ListView):
     template_name = 'profile/dashboard.html'
 
     def dispatch(self, request, *args, **kwargs):
-        user_profile = Profile.objects.get(
-            user__id=self.request.user.id)
+        user_profile = get_object_or_404(
+            Profile, user__id=self.request.user.id)
         if not user_profile.get_user_type:
             return redirect('profiles:profile-edit',
                             slug=request.user.username)

--- a/wye/reports/admin.py
+++ b/wye/reports/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+# from django.contrib import admin
 
 # Register your models here.

--- a/wye/reports/models.py
+++ b/wye/reports/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+# from django.db import models
 
 # Create your models here.


### PR DESCRIPTION
There was a query to profile Model that was failing in this case, so now
throwing 404 instead.

```python
Internal Server Error: /dashboard/
Traceback (most recent call last):
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "./wye/profiles/views.py", line 35, in dispatch
    user__id=self.request.user.id)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/opt/envs/wye/local/lib/python2.7/site-packages/django/db/models/query.py", line 334, in get
    self.model._meta.object_name
DoesNotExist: Profile matching query does not exist.
```
