### PR TITLE
UI consistency for upcoming.html template

### DIFF
--- a/wye/templates/upcoming.html
+++ b/wye/templates/upcoming.html
@@ -8,7 +8,7 @@
 {% endblock %}
 {% block extracss %}
 
-<link href="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet" />
+<!--<link href="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet" />-->
 <link href="https://cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.css" rel="stylesheet" />
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 <script src="https://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>


### PR DESCRIPTION
This is for the inconsistency found in "upcoming workshop" template . 

Below is the UI layout.

![screenshot_20160926_231132](https://cloud.githubusercontent.com/assets/8580742/18846085/f841e2b2-8441-11e6-856b-19f601af14f7.png)


Which clearly doesn't match with the rest of the layout.For eg:

![screenshot_20160926_231141](https://cloud.githubusercontent.com/assets/8580742/18846117/129e69c8-8442-11e6-8bb2-fa2d2e7f3cdc.png)

@vnbang2003 make-do fix as of now.My first for wye project.
