### PR TITLE
Updating requirements.txt to replace psycopg2 with psycopg-binary

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ unicode-slugify==0.1.3
 
 # Persistent Store
 # --------------------------------------
-psycopg2==2.7.3
+psycopg-binary==2.7.3
 
 # Rest FrameWork
 #---------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ unicode-slugify==0.1.3
 
 # Persistent Store
 # --------------------------------------
-psycopg-binary==2.8.3
+psycopg2-binary==2.8.3
 
 # Rest FrameWork
 #---------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ unicode-slugify==0.1.3
 
 # Persistent Store
 # --------------------------------------
-psycopg-binary==2.7.3
+psycopg-binary==2.8.3
 
 # Rest FrameWork
 #---------------------------------------


### PR DESCRIPTION
Pycopg2 is creating issues in Python3.6

```
python manage.py migrate
Traceback (most recent call last):
  File "/home/deepshar/projects/wye/venv36/lib64/python3.6/site-packages/django/db/backends/postgresql_psycopg2/base.py", line 20, in <module>
    import psycopg2 as Database
  File "/home/deepshar/projects/wye/venv36/lib64/python3.6/site-packages/psycopg2/__init__.py", line 50, in <module>
    from psycopg2._psycopg import (                     # noqa
ImportError: /home/deepshar/projects/wye/venv36/lib64/python3.6/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
```